### PR TITLE
FIX #34 Multiprocess enabled for e10s

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "keywords": [
     "read", "wallabag"
   ],
+  "permissions": {
+    "multiprocess": true
+  },
   "preferences": [
     {
         "name": "wallabagUrl",


### PR DESCRIPTION
Activation of [e10s](https://wiki.mozilla.org/Electrolysis) on Firefox >= 50.

Have a good night! 🌙 